### PR TITLE
Unsupported media type error fix

### DIFF
--- a/backend/src/main/java/com/example/syncmeet/controller/BlogController.java
+++ b/backend/src/main/java/com/example/syncmeet/controller/BlogController.java
@@ -30,9 +30,9 @@ public class BlogController {
 
     @PostMapping("blog/{authorId}")
     public ResponseEntity<BlogDTO> createBlogPost(
-            @Valid @RequestBody BlogCreationRequestDTO blogDTO,
+            @Valid @RequestPart("data") BlogCreationRequestDTO blogDTO,
             @PathVariable UUID authorId,
-            @RequestBody MultipartFile image
+            @RequestPart("image") MultipartFile image
     )
     {
         BlogDTO blog = new BlogDTO();

--- a/backend/src/main/java/com/example/syncmeet/controller/UserController.java
+++ b/backend/src/main/java/com/example/syncmeet/controller/UserController.java
@@ -110,8 +110,8 @@ public class UserController {
      */
     @PostMapping("/users")
     public ResponseEntity<UserDTO> signUp(
-            @Valid @RequestBody UserSignUpRequestDTO userSignUpRequest,
-            @RequestBody MultipartFile image
+            @Valid @RequestPart("data") UserSignUpRequestDTO userSignUpRequest,
+            @RequestPart("image") MultipartFile image
             ) {
         UserDTO user = new UserDTO(
                 null,

--- a/backend/src/main/java/com/example/syncmeet/service/impl/S3ServiceImpl.java
+++ b/backend/src/main/java/com/example/syncmeet/service/impl/S3ServiceImpl.java
@@ -12,7 +12,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Uri;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -43,7 +42,6 @@ public class S3ServiceImpl implements S3Service {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(fileName)
-                    .acl(ObjectCannedACL.PUBLIC_READ)
                     .build();
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
         } catch (IOException e) {


### PR DESCRIPTION
Removed ACL canning from S3 client creation, replaced `RequestBody` with `RequestPart` in requests with both JSON and image data types in body